### PR TITLE
feat: arguments for actions and conditions

### DIFF
--- a/.github/workflows/prchecks-test.yml
+++ b/.github/workflows/prchecks-test.yml
@@ -1,0 +1,29 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ master ]
+
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: npm test

--- a/dist/index.js
+++ b/dist/index.js
@@ -78,15 +78,23 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
+/* unused harmony export StateNameEnum */
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return State; });
 /**
  * Enumeration of node states.
  */
+const StateNameEnum = {
+    READY: "mistreevous.ready",
+    RUNNING: "mistreevous.running",
+    SUCCEEDED: "mistreevous.succeeded",
+    FAILED: "mistreevous.failed"
+};
+
 const State = {
-    READY: Symbol("mistreevous.ready"),
-    RUNNING: Symbol("mistreevous.running"),
-    SUCCEEDED: Symbol("mistreevous.succeeded"),
-    FAILED: Symbol("mistreevous.failed")
+    READY: Symbol(StateNameEnum.READY),
+    RUNNING: Symbol(StateNameEnum.RUNNING),
+    SUCCEEDED: Symbol(StateNameEnum.SUCCEEDED),
+    FAILED: Symbol(StateNameEnum.FAILED)
 };
 
 
@@ -109,53 +117,53 @@ const State = {
  * @param children The child nodes. 
  */
 function Composite(type, decorators, children) {
-    __WEBPACK_IMPORTED_MODULE_0__node__["a" /* default */].call(this, type, decorators);
+  __WEBPACK_IMPORTED_MODULE_0__node__["a" /* default */].call(this, type, decorators);
 
-    /**
-     * Gets whether this node is a leaf node.
-     */
-    this.isLeafNode = () => false;
+  /**
+   * Gets whether this node is a leaf node.
+   */
+  this.isLeafNode = () => false;
 
-    /**
-     * Gets the children of this node.
-     */
-    this.getChildren = () => children;
+  /**
+   * Gets the children of this node.
+   */
+  this.getChildren = () => children;
 
-    /**
-     * Reset the state of the node.
-     */
-    this.reset = () => {
-        // Reset the state of this node.
-        this.setState(__WEBPACK_IMPORTED_MODULE_1__state__["a" /* default */].READY);
+  /**
+   * Reset the state of the node.
+   */
+  this.reset = () => {
+    // Reset the state of this node.
+    this.setState(__WEBPACK_IMPORTED_MODULE_1__state__["a" /* default */].READY);
 
-        // Reset the state of any child nodes.
-        this.getChildren().forEach(child => child.reset());
-    };
+    // Reset the state of any child nodes.
+    this.getChildren().forEach(child => child.reset());
+  };
 
-    /**
-     * Abort the running of this node.
-     * @param board The board.
-     */
-    this.abort = board => {
-        // There is nothing to do if this node is not in the running state.
-        if (!this.is(__WEBPACK_IMPORTED_MODULE_1__state__["a" /* default */].RUNNING)) {
-            return;
-        }
+  /**
+   * Abort the running of this node.
+   * @param board The board.
+   */
+  this.abort = board => {
+    // There is nothing to do if this node is not in the running state.
+    if (!this.is(__WEBPACK_IMPORTED_MODULE_1__state__["a" /* default */].RUNNING)) {
+      return;
+    }
 
-        // Abort any child nodes.
-        this.getChildren().forEach(child => child.abort(board));
+    // Abort any child nodes.
+    this.getChildren().forEach(child => child.abort(board));
 
-        // Reset the state of this node.
-        this.reset();
+    // Reset the state of this node.
+    this.reset();
 
-        // Try to get the exit decorator for this node.
-        const exitDecorator = this.getDecorator("exit");
+    // Try to get the exit decorator for this node.
+    const exitDecorator = this.getDecorator("exit");
 
-        // Call the exit decorator function if it exists.
-        if (exitDecorator) {
-            exitDecorator.callBlackboardFunction(board, false, true);
-        }
-    };
+    // Call the exit decorator function if it exists.
+    if (exitDecorator) {
+      exitDecorator.callBlackboardFunction(board, false, true);
+    }
+  };
 };
 
 Composite.prototype = Object.create(__WEBPACK_IMPORTED_MODULE_0__node__["a" /* default */].prototype);
@@ -170,7 +178,11 @@ Composite.prototype = Object.create(__WEBPACK_IMPORTED_MODULE_0__node__["a" /* d
  * A base node decorator.
  * @param type The node decorator type.
  */
-function Decorator(type) {
+function Decorator(type, args) {
+  /**
+   * Gets the arguments
+  */
+  this.getArguments = () => args || [];
 
   /**
    * Gets the type of the node.
@@ -470,12 +482,12 @@ function BehaviourTree(definition, board) {
     this._init = function () {
         // The tree definition must be defined and a valid string.
         if (typeof definition !== "string") {
-            throw new Error("the tree definition must be a string");
+            throw new Error(BehaviourTree.ERROR_DEFINITION_IS_NOT_A_STRING);
         }
 
         // The blackboard must be defined.
         if (typeof board !== 'object' || board === null) {
-            throw new Error("the blackboard must be defined");
+            throw new Error(BehaviourTree.ERROR_BLACKBOARD_UNDEFINED);
         }
 
         // Convert the definition into an array of raw tokens.
@@ -486,7 +498,7 @@ function BehaviourTree(definition, board) {
             const rootASTNodes = Object(__WEBPACK_IMPORTED_MODULE_1__rootASTNodesBuilder__["a" /* default */])(tokens);
 
             // Create a symbol to use as the main root key in our root node mapping.
-            const mainRootNodeKey = Symbol("__root__");
+            const mainRootNodeKey = Symbol(BehaviourTree.SYMBOL_ROOT_MONIKER);
 
             // Create a mapping of root node names to root AST tokens. The main root node will have a key of Symbol("__root__").
             const rootNodeMap = {};
@@ -506,7 +518,7 @@ function BehaviourTree(definition, board) {
             this._applyLeafNodeGuardPaths();
         } catch (exception) {
             // There was an issue in trying to parse and build the tree definition.
-            throw new Error(`error parsing tree: ${exception}`);
+            throw new Error(BehaviourTree.ERROR_TREE_PARSE.replace('{error}', exception));
         }
     };
 
@@ -566,7 +578,7 @@ function BehaviourTree(definition, board) {
             // Add the current node to the path.
             path = path.concat(node);
 
-            // Check whether the current node is a leaf node. 
+            // Check whether the current node is a leaf node.
             if (node.isLeafNode()) {
                 nodePaths.push(path);
             } else {
@@ -583,6 +595,12 @@ function BehaviourTree(definition, board) {
     // Call init logic.
     this._init();
 }
+
+BehaviourTree.ERROR_DEFINITION_IS_NOT_A_STRING = "the tree definition must be a string";
+BehaviourTree.ERROR_BLACKBOARD_UNDEFINED = "the blackboard must be defined";
+BehaviourTree.ERROR_TREE_PARSE = "error parsing tree: {error}";
+BehaviourTree.ERROR_TREE_STEP = "error stepping tree: {error}";
+BehaviourTree.SYMBOL_ROOT_MONIKER = "__root__";
 
 /**
  * Gets the root node.
@@ -663,7 +681,7 @@ BehaviourTree.prototype.step = function () {
     try {
         this._rootNode.update(this._blackboard);
     } catch (exception) {
-        throw new Error(`error stepping tree: ${exception}`);
+        throw new Error(BehaviourTree.ERROR_TREE_STEP.replace('{error}', exception));
     }
 };
 
@@ -748,11 +766,11 @@ function GuardPath(nodes) {
  * The node decorator factories.
  */
 const DecoratorFactories = {
-    "WHILE": condition => new __WEBPACK_IMPORTED_MODULE_10__decorators_guards_while__["a" /* default */](condition),
-    "UNTIL": condition => new __WEBPACK_IMPORTED_MODULE_11__decorators_guards_until__["a" /* default */](condition),
-    "ENTRY": functionName => new __WEBPACK_IMPORTED_MODULE_12__decorators_entry__["a" /* default */](functionName),
-    "EXIT": functionName => new __WEBPACK_IMPORTED_MODULE_13__decorators_exit__["a" /* default */](functionName),
-    "STEP": functionName => new __WEBPACK_IMPORTED_MODULE_14__decorators_step__["a" /* default */](functionName)
+    "WHILE": (condition, args) => new __WEBPACK_IMPORTED_MODULE_10__decorators_guards_while__["a" /* default */](condition, args),
+    "UNTIL": (condition, args) => new __WEBPACK_IMPORTED_MODULE_11__decorators_guards_until__["a" /* default */](condition, args),
+    "ENTRY": (functionName, args) => new __WEBPACK_IMPORTED_MODULE_12__decorators_entry__["a" /* default */](functionName, args),
+    "EXIT": (functionName, args) => new __WEBPACK_IMPORTED_MODULE_13__decorators_exit__["a" /* default */](functionName, args),
+    "STEP": (functionName, args) => new __WEBPACK_IMPORTED_MODULE_14__decorators_step__["a" /* default */](functionName, args)
 };
 
 /**
@@ -869,14 +887,14 @@ const ASTNodeFactories = {
                 throw "a repeat node must have a single child";
             }
 
-            // A repeat node must have a positive number of iterations if defined. 
+            // A repeat node must have a positive number of iterations if defined.
             if (this.iterations !== null && this.iterations < 0) {
                 throw "a repeat node must have a positive number of iterations if defined";
             }
 
             // There is validation to carry out if a longest duration was defined.
             if (this.maximumIterations !== null) {
-                // A repeat node must have a positive maximum iterations count if defined. 
+                // A repeat node must have a positive maximum iterations count if defined.
                 if (this.maximumIterations < 0) {
                     throw "a repeat node must have a positive maximum iterations count if defined";
                 }
@@ -909,9 +927,10 @@ const ASTNodeFactories = {
         type: "condition",
         decorators: [],
         conditionFunction: "",
+        conditionArguments: [],
         validate: function (depth) {},
         createNodeInstance: function (namedRootNodeProvider, visitedBranches) {
-            return new __WEBPACK_IMPORTED_MODULE_1__nodes_condition__["a" /* default */](this.decorators, this.conditionFunction);
+            return new __WEBPACK_IMPORTED_MODULE_1__nodes_condition__["a" /* default */](this.decorators, this.conditionFunction, this.conditionArguments);
         }
     }),
     "WAIT": () => ({
@@ -920,14 +939,14 @@ const ASTNodeFactories = {
         duration: null,
         longestDuration: null,
         validate: function (depth) {
-            // A wait node must have a positive duration. 
+            // A wait node must have a positive duration.
             if (this.duration < 0) {
                 throw "a wait node must have a positive duration";
             }
 
             // There is validation to carry out if a longest duration was defined.
             if (this.longestDuration) {
-                // A wait node must have a positive longest duration. 
+                // A wait node must have a positive longest duration.
                 if (this.longestDuration < 0) {
                     throw "a wait node must have a positive longest duration if one is defined";
                 }
@@ -946,9 +965,10 @@ const ASTNodeFactories = {
         type: "action",
         decorators: [],
         actionName: "",
+        actionsArguments: [],
         validate: function (depth) {},
         createNodeInstance: function (namedRootNodeProvider, visitedBranches) {
-            return new __WEBPACK_IMPORTED_MODULE_0__nodes_action__["a" /* default */](this.decorators, this.actionName);
+            return new __WEBPACK_IMPORTED_MODULE_0__nodes_action__["a" /* default */](this.decorators, this.actionName, this.actionsArguments);
         }
     })
 };
@@ -1118,14 +1138,8 @@ function buildRootASTNodes(tokens) {
 
                 // The condition name will be defined as a node argument.
                 const conditionArguments = getArguments(tokens);
-
-                // We should have only a single argument that is not an empty string for a condition node, which is the condition function name.
-                if (conditionArguments.length === 1 && conditionArguments[0] !== "") {
-                    // The condition function name will be the first and only node argument.
-                    node.conditionFunction = conditionArguments[0];
-                } else {
-                    throw "expected single condition name argument";
-                }
+                node.conditionFunction = conditionArguments.pop();
+                node.conditionArguments = conditionArguments;
 
                 // Try to pick any decorators off of the token stack.
                 node.decorators = getDecorators(tokens);
@@ -1223,14 +1237,8 @@ function buildRootASTNodes(tokens) {
 
                 // The action name will be defined as a node argument.
                 const actionArguments = getArguments(tokens);
-
-                // We should have only a single argument that is not an empty string for an action node, which is the action name.
-                if (actionArguments.length === 1 && actionArguments[0] !== "") {
-                    // The action name will be the first and only node argument.
-                    node.actionName = actionArguments[0];
-                } else {
-                    throw "expected single action name argument";
-                }
+                node.actionName = actionArguments.pop();
+                node.actionArguments = actionArguments;
 
                 // Try to pick any decorators off of the token stack.
                 node.decorators = getDecorators(tokens);
@@ -1373,7 +1381,7 @@ function getArguments(tokens, argumentValidator, validationFailedMessage) {
  * @returns An array od decorators defined by any directly following tokens.
  */
 function getDecorators(tokens) {
-    // Create an array to hold any decorators found. 
+    // Create an array to hold any decorators found.
     const decorators = [];
 
     // Keep track of names of decorators that we have found on the token stack, as we cannot have duplicates.
@@ -1394,11 +1402,18 @@ function getDecorators(tokens) {
         // The decorator definition should consist of the tokens 'NAME', '(', 'ARGUMENT' and ')'.
         popAndCheck(tokens, tokens[0].toUpperCase());
         popAndCheck(tokens, "(");
-        const decoratorArgument = popAndCheck(tokens);
-        popAndCheck(tokens, ")");
+
+        // store decorator name, condition, and condition arguments
+        const decoratorArguments = [];
+        const decoratorName = popAndCheck(tokens);
+        let arg = popAndCheck(tokens);
+        while (arg !== ")") {
+            decoratorArguments.push(arg);
+            arg = popAndCheck(tokens);
+        }
 
         // Create the decorator and add it to the array of decorators found.
-        decorators.push(decoratorFactory(decoratorArgument));
+        decorators.push(decoratorFactory(decoratorName, decoratorArguments));
 
         // Try to get the next decorator name token, as there could be multiple.
         decoratorFactory = DecoratorFactories[(tokens[0] || "").toUpperCase()];
@@ -1424,11 +1439,11 @@ function getDecorators(tokens) {
  * @param decorators The node decorators.
  * @param actionName The action name.
  */
-function Action(decorators, actionName) {
+function Action(decorators, actionName, actionArguments) {
     __WEBPACK_IMPORTED_MODULE_0__leaf__["a" /* default */].call(this, "action", decorators);
 
     /**
-     * Whether there is a pending update promise. 
+     * Whether there is a pending update promise.
      */
     let isUsingUpdatePromise = false;
 
@@ -1465,7 +1480,7 @@ function Action(decorators, actionName) {
         // - The finished state of this action node.
         // - A promise to return a finished node state.
         // - Undefined if the node should remain in the running state.
-        const updateResult = action.call(board);
+        const updateResult = action.apply(board, actionArguments || []);
 
         if (updateResult instanceof Promise) {
             updateResult.then(result => {
@@ -1571,9 +1586,9 @@ Action.prototype = Object.create(__WEBPACK_IMPORTED_MODULE_0__leaf__["a" /* defa
  * A Condition leaf node.
  * This will succeed or fail immediately based on a board predicate, without moving to the 'RUNNING' state.
  * @param decorators The node decorators.
- * @param condition The name of the condition function. 
+ * @param condition The name of the condition function.
  */
-function Condition(decorators, condition) {
+function Condition(decorators, condition, conditionArguments) {
     __WEBPACK_IMPORTED_MODULE_0__leaf__["a" /* default */].call(this, "condition", decorators);
 
     /**
@@ -1584,7 +1599,7 @@ function Condition(decorators, condition) {
     this.onUpdate = function (board) {
         // Call the condition function to determine the state of this node, but it must exist in the blackboard.
         if (typeof board[condition] === "function") {
-            this.setState(!!board[condition].call(board) ? __WEBPACK_IMPORTED_MODULE_1__state__["a" /* default */].SUCCEEDED : __WEBPACK_IMPORTED_MODULE_1__state__["a" /* default */].FAILED);
+            this.setState(!!board[condition].apply(board, conditionArguments || []) ? __WEBPACK_IMPORTED_MODULE_1__state__["a" /* default */].SUCCEEDED : __WEBPACK_IMPORTED_MODULE_1__state__["a" /* default */].FAILED);
         } else {
             throw `cannot update condition node as function '${condition}' is not defined in the blackboard`;
         }
@@ -2225,48 +2240,48 @@ Parallel.prototype = Object.create(__WEBPACK_IMPORTED_MODULE_0__composite__["a" 
  * @param longestDuration The longest possible duration in milliseconds that this node will wait to succeed.
  */
 function Wait(decorators, duration, longestDuration) {
-    __WEBPACK_IMPORTED_MODULE_0__leaf__["a" /* default */].call(this, "wait", decorators);
+  __WEBPACK_IMPORTED_MODULE_0__leaf__["a" /* default */].call(this, "wait", decorators);
 
-    /** 
-     * The time in milliseconds at which this node was first updated.
-     */
-    let initialUpdateTime;
+  /** 
+   * The time in milliseconds at which this node was first updated.
+   */
+  let initialUpdateTime;
 
-    /**
-     * The duration in milliseconds that this node will be waiting for. 
-     */
-    let waitDuration;
+  /**
+   * The duration in milliseconds that this node will be waiting for. 
+   */
+  let waitDuration;
 
-    /**
-     * Update the node.
-     * @param board The board.
-     * @returns The result of the update.
-     */
-    this.onUpdate = function (board) {
-        // If this node is in the READY state then we need to set the initial update time.
-        if (this.is(__WEBPACK_IMPORTED_MODULE_1__state__["a" /* default */].READY)) {
-            // Set the initial update time.
-            initialUpdateTime = new Date().getTime();
+  /**
+   * Update the node.
+   * @param board The board.
+   * @returns The result of the update.
+   */
+  this.onUpdate = function (board) {
+    // If this node is in the READY state then we need to set the initial update time.
+    if (this.is(__WEBPACK_IMPORTED_MODULE_1__state__["a" /* default */].READY)) {
+      // Set the initial update time.
+      initialUpdateTime = new Date().getTime();
 
-            // If a longestDuration value was defined then we will be randomly picking a duration between the
-            // shortest and longest duration. If it was not defined, then we will be just using the duration.
-            waitDuration = longestDuration ? Math.floor(Math.random() * (longestDuration - duration + 1) + duration) : duration;
+      // If a longestDuration value was defined then we will be randomly picking a duration between the
+      // shortest and longest duration. If it was not defined, then we will be just using the duration.
+      waitDuration = longestDuration ? Math.floor(Math.random() * (longestDuration - duration + 1) + duration) : duration;
 
-            // The node is now running until we finish waiting.
-            this.setState(__WEBPACK_IMPORTED_MODULE_1__state__["a" /* default */].RUNNING);
-        }
+      // The node is now running until we finish waiting.
+      this.setState(__WEBPACK_IMPORTED_MODULE_1__state__["a" /* default */].RUNNING);
+    }
 
-        // Have we waited long enough?
-        if (new Date().getTime() >= initialUpdateTime + waitDuration) {
-            // We have finished waiting!
-            this.setState(__WEBPACK_IMPORTED_MODULE_1__state__["a" /* default */].SUCCEEDED);
-        }
-    };
+    // Have we waited long enough?
+    if (new Date().getTime() >= initialUpdateTime + waitDuration) {
+      // We have finished waiting!
+      this.setState(__WEBPACK_IMPORTED_MODULE_1__state__["a" /* default */].SUCCEEDED);
+    }
+  };
 
-    /**
-     * Gets the name of the node.
-     */
-    this.getName = () => `WAIT ${longestDuration ? duration + "ms-" + longestDuration + "ms" : duration + "ms"}`;
+  /**
+   * Gets the name of the node.
+   */
+  this.getName = () => `WAIT ${longestDuration ? duration + "ms-" + longestDuration + "ms" : duration + "ms"}`;
 };
 
 Wait.prototype = Object.create(__WEBPACK_IMPORTED_MODULE_0__leaf__["a" /* default */].prototype);
@@ -2284,8 +2299,8 @@ Wait.prototype = Object.create(__WEBPACK_IMPORTED_MODULE_0__leaf__["a" /* defaul
  * A WHILE guard which is satisfied as long as the given condition remains true.
  * @param condition The name of the condition function that determines whether the guard is satisfied.
  */
-function While(condition) {
-    __WEBPACK_IMPORTED_MODULE_0__decorator__["a" /* default */].call(this, "while");
+function While(condition, ...args) {
+    __WEBPACK_IMPORTED_MODULE_0__decorator__["a" /* default */].call(this, "while", args);
 
     /**
      * Gets whether the decorator is a guard.
@@ -2304,7 +2319,8 @@ function While(condition) {
         return {
             type: this.getType(),
             isGuard: this.isGuard(),
-            condition: this.getCondition()
+            condition: this.getCondition(),
+            arguments: this.getArguments()
         };
     };
 
@@ -2316,7 +2332,7 @@ function While(condition) {
     this.isSatisfied = board => {
         // Call the condition function to determine whether this guard is satisfied.
         if (typeof board[condition] === "function") {
-            return !!board[condition].call(board);
+            return !!board[condition].apply(board, this.getArguments());
         } else {
             throw `cannot evaluate node guard as function '${condition}' is not defined in the blackboard`;
         }
@@ -2338,8 +2354,8 @@ While.prototype = Object.create(__WEBPACK_IMPORTED_MODULE_0__decorator__["a" /* 
  * An UNTIL guard which is satisfied as long as the given condition remains false.
  * @param condition The name of the condition function that determines whether the guard is satisfied.
  */
-function Until(condition) {
-    __WEBPACK_IMPORTED_MODULE_0__decorator__["a" /* default */].call(this, "until");
+function Until(condition, args) {
+    __WEBPACK_IMPORTED_MODULE_0__decorator__["a" /* default */].call(this, "until", args);
 
     /**
      * Gets whether the decorator is a guard.
@@ -2358,7 +2374,8 @@ function Until(condition) {
         return {
             type: this.getType(),
             isGuard: this.isGuard(),
-            condition: this.getCondition()
+            condition: this.getCondition(),
+            arguments: this.getArguments()
         };
     };
 
@@ -2370,7 +2387,7 @@ function Until(condition) {
     this.isSatisfied = board => {
         // Call the condition function to determine whether this guard is satisfied.
         if (typeof board[condition] === "function") {
-            return !!!board[condition].call(board);
+            return !!!board[condition].apply(board, this.getArguments());
         } else {
             throw `cannot evaluate node guard as function '${condition}' is not defined in the blackboard`;
         }
@@ -2392,8 +2409,8 @@ Until.prototype = Object.create(__WEBPACK_IMPORTED_MODULE_0__decorator__["a" /* 
  * An ENTRY decorator which defines a blackboard function to call when the decorated node is updated and moves out of running state.
  * @param functionName The name of the blackboard function to call.
  */
-function Entry(functionName) {
-    __WEBPACK_IMPORTED_MODULE_0__decorator__["a" /* default */].call(this, "entry");
+function Entry(functionName, args) {
+    __WEBPACK_IMPORTED_MODULE_0__decorator__["a" /* default */].call(this, "entry", args);
 
     /**
      * Gets the function name.
@@ -2407,7 +2424,8 @@ function Entry(functionName) {
         return {
             type: this.getType(),
             isGuard: this.isGuard(),
-            functionName: this.getFunctionName()
+            functionName: this.getFunctionName(),
+            arguments: this.getArguments()
         };
     };
 
@@ -2418,7 +2436,7 @@ function Entry(functionName) {
     this.callBlackboardFunction = board => {
         // Call the blackboard function if it exists.
         if (typeof board[functionName] === "function") {
-            board[functionName].call(board);
+            board[functionName].apply(board, this.getArguments());
         } else {
             throw `cannot call entry decorator function '${functionName}' is not defined in the blackboard`;
         }
@@ -2440,8 +2458,8 @@ Entry.prototype = Object.create(__WEBPACK_IMPORTED_MODULE_0__decorator__["a" /* 
  * An EXIT decorator which defines a blackboard function to call when the decorated node is updated and moves to a finished state or is aborted.
  * @param functionName The name of the blackboard function to call.
  */
-function Exit(functionName) {
-    __WEBPACK_IMPORTED_MODULE_0__decorator__["a" /* default */].call(this, "exit");
+function Exit(functionName, args) {
+    __WEBPACK_IMPORTED_MODULE_0__decorator__["a" /* default */].call(this, "exit", args);
 
     /**
      * Gets the function name.
@@ -2455,7 +2473,8 @@ function Exit(functionName) {
         return {
             type: this.getType(),
             isGuard: this.isGuard(),
-            functionName: this.getFunctionName()
+            functionName: this.getFunctionName(),
+            arguments: this.getArguments()
         };
     };
 
@@ -2468,7 +2487,7 @@ function Exit(functionName) {
     this.callBlackboardFunction = (board, isSuccess, isAborted) => {
         // Call the blackboard function if it exists.
         if (typeof board[functionName] === "function") {
-            board[functionName].call(board, { succeeded: isSuccess, aborted: isAborted });
+            board[functionName].apply(board, [{ succeeded: isSuccess, aborted: isAborted }].concat(this.getArguments()));
         } else {
             throw `cannot call exit decorator function '${functionName}' is not defined in the blackboard`;
         }
@@ -2490,8 +2509,8 @@ Exit.prototype = Object.create(__WEBPACK_IMPORTED_MODULE_0__decorator__["a" /* d
  * A STEP decorator which defines a blackboard function to call when the decorated node is updated.
  * @param functionName The name of the blackboard function to call.
  */
-function Step(functionName) {
-    __WEBPACK_IMPORTED_MODULE_0__decorator__["a" /* default */].call(this, "step");
+function Step(functionName, args) {
+    __WEBPACK_IMPORTED_MODULE_0__decorator__["a" /* default */].call(this, "step", args);
 
     /**
      * Gets the function name.
@@ -2505,7 +2524,8 @@ function Step(functionName) {
         return {
             type: this.getType(),
             isGuard: this.isGuard(),
-            functionName: this.getFunctionName()
+            functionName: this.getFunctionName(),
+            arguments: this.getArguments()
         };
     };
 
@@ -2516,7 +2536,7 @@ function Step(functionName) {
     this.callBlackboardFunction = board => {
         // Call the blackboard function if it exists.
         if (typeof board[functionName] === "function") {
-            board[functionName].call(board);
+            board[functionName].apply(board, this.getArguments());
         } else {
             throw `cannot call entry decorator function '${functionName}' is not defined in the blackboard`;
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mistreevous",
-  "version": "1.1.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/behaviourtree.js
+++ b/src/behaviourtree.js
@@ -23,12 +23,12 @@ export default function BehaviourTree(definition, board) {
     this._init = function() {
         // The tree definition must be defined and a valid string.
         if (typeof definition !== "string") {
-            throw new Error("the tree definition must be a string");
+            throw new Error(BehaviourTree.ERROR_DEFINITION_IS_NOT_A_STRING);
         }
 
         // The blackboard must be defined.
         if (typeof board !== 'object' || board === null) {
-            throw new Error("the blackboard must be defined");
+            throw new Error(BehaviourTree.ERROR_BLACKBOARD_UNDEFINED);
         }
 
         // Convert the definition into an array of raw tokens.
@@ -39,7 +39,7 @@ export default function BehaviourTree(definition, board) {
             const rootASTNodes = buildRootASTNodes(tokens);
 
             // Create a symbol to use as the main root key in our root node mapping.
-            const mainRootNodeKey = Symbol("__root__");
+            const mainRootNodeKey = Symbol(BehaviourTree.SYMBOL_ROOT_MONIKER);
 
             // Create a mapping of root node names to root AST tokens. The main root node will have a key of Symbol("__root__").
             const rootNodeMap = {};
@@ -57,7 +57,7 @@ export default function BehaviourTree(definition, board) {
             this._applyLeafNodeGuardPaths();
         } catch (exception) {
             // There was an issue in trying to parse and build the tree definition.
-            throw new Error(`error parsing tree: ${exception}`);
+            throw new Error(BehaviourTree.ERROR_TREE_PARSE.replace('{error}', exception));
         }
     };
 
@@ -122,7 +122,7 @@ export default function BehaviourTree(definition, board) {
             // Add the current node to the path.
             path = path.concat(node);
 
-            // Check whether the current node is a leaf node. 
+            // Check whether the current node is a leaf node.
             if (node.isLeafNode()) {
                 nodePaths.push(path);
             } else {
@@ -139,6 +139,12 @@ export default function BehaviourTree(definition, board) {
     // Call init logic.
     this._init();
 }
+
+BehaviourTree.ERROR_DEFINITION_IS_NOT_A_STRING = "the tree definition must be a string"
+BehaviourTree.ERROR_BLACKBOARD_UNDEFINED = "the blackboard must be defined"
+BehaviourTree.ERROR_TREE_PARSE = "error parsing tree: {error}"
+BehaviourTree.ERROR_TREE_STEP = "error stepping tree: {error}"
+BehaviourTree.SYMBOL_ROOT_MONIKER = "__root__"
 
 /**
  * Gets the root node.
@@ -171,9 +177,9 @@ BehaviourTree.prototype.getFlattenedNodeDetails = function () {
             decorators.length > 0 ? decorators.map((decorator) => decorator.getDetails()) : null;
 
         // Push the current node into the flattened nodes array.
-        flattenedTreeNodes.push({ 
+        flattenedTreeNodes.push({
             id: node.getUid(),
-            type: node.getType(), 
+            type: node.getType(),
             caption: node.getName(),
             state: node.getState(),
             decorators: getDecoratorDetails(node.getDecorators()),
@@ -220,7 +226,7 @@ BehaviourTree.prototype.step = function () {
     try {
         this._rootNode.update(this._blackboard);
     } catch (exception) {
-        throw new Error(`error stepping tree: ${exception}`);
+        throw new Error(BehaviourTree.ERROR_TREE_STEP.replace('{error}', exception));
     }
 };
 

--- a/src/decorators/decorator.js
+++ b/src/decorators/decorator.js
@@ -2,13 +2,17 @@
  * A base node decorator.
  * @param type The node decorator type.
  */
-export default function Decorator(type) {
-  
+export default function Decorator(type, args) {
+    /**
+     * Gets the arguments
+    */
+    this.getArguments = () => args || [];
+
     /**
      * Gets the type of the node.
      */
     this.getType = () => type;
-  
+
     /**
      * Gets whether the decorator is a guard.
      */

--- a/src/decorators/entry.js
+++ b/src/decorators/entry.js
@@ -4,8 +4,8 @@ import Decorator from './decorator'
  * An ENTRY decorator which defines a blackboard function to call when the decorated node is updated and moves out of running state.
  * @param functionName The name of the blackboard function to call.
  */
-export default function Entry(functionName, ...args) {
-    Decorator.call(this, "entry");
+export default function Entry(functionName, args) {
+    Decorator.call(this, "entry", args);
 
     /**
      * Gets the function name.
@@ -20,7 +20,7 @@ export default function Entry(functionName, ...args) {
             type: this.getType(),
             isGuard: this.isGuard(),
             functionName: this.getFunctionName(),
-            arguments: args
+            arguments: this.getArguments()
         };
     };
 
@@ -31,7 +31,7 @@ export default function Entry(functionName, ...args) {
     this.callBlackboardFunction = (board) => {
         // Call the blackboard function if it exists.
         if (typeof board[functionName] === "function") {
-            board[functionName].apply(board, args || []);
+            board[functionName].apply(board, this.getArguments());
         } else {
             throw `cannot call entry decorator function '${functionName}' is not defined in the blackboard`;
         }

--- a/src/decorators/entry.js
+++ b/src/decorators/entry.js
@@ -4,7 +4,7 @@ import Decorator from './decorator'
  * An ENTRY decorator which defines a blackboard function to call when the decorated node is updated and moves out of running state.
  * @param functionName The name of the blackboard function to call.
  */
-export default function Entry(functionName) {
+export default function Entry(functionName, ...args) {
     Decorator.call(this, "entry");
 
     /**
@@ -19,7 +19,8 @@ export default function Entry(functionName) {
         return {
             type: this.getType(),
             isGuard: this.isGuard(),
-            functionName: this.getFunctionName()
+            functionName: this.getFunctionName(),
+            arguments: args
         };
     };
 
@@ -30,7 +31,7 @@ export default function Entry(functionName) {
     this.callBlackboardFunction = (board) => {
         // Call the blackboard function if it exists.
         if (typeof board[functionName] === "function") {
-            board[functionName].call(board);
+            board[functionName].apply(board, args || []);
         } else {
             throw `cannot call entry decorator function '${functionName}' is not defined in the blackboard`;
         }

--- a/src/decorators/exit.js
+++ b/src/decorators/exit.js
@@ -4,8 +4,8 @@ import Decorator from './decorator'
  * An EXIT decorator which defines a blackboard function to call when the decorated node is updated and moves to a finished state or is aborted.
  * @param functionName The name of the blackboard function to call.
  */
-export default function Exit(functionName, ...args) {
-    Decorator.call(this, "exit");
+export default function Exit(functionName, args) {
+    Decorator.call(this, "exit", args);
 
     /**
      * Gets the function name.
@@ -20,7 +20,7 @@ export default function Exit(functionName, ...args) {
             type: this.getType(),
             isGuard: this.isGuard(),
             functionName: this.getFunctionName(),
-            arguments: args || []
+            arguments: this.getArguments()
         };
     };
 
@@ -33,10 +33,10 @@ export default function Exit(functionName, ...args) {
     this.callBlackboardFunction = (board, isSuccess, isAborted) => {
         // Call the blackboard function if it exists.
         if (typeof board[functionName] === "function") {
-            board[functionName].call(board, 
-                                     { succeeded: isSuccess, aborted: isAborted },
-                                     ...(args || [])
-                                    );
+            board[functionName].apply(board,
+                [{ succeeded: isSuccess, aborted: isAborted }]
+                    .concat(this.getArguments())
+            );
         } else {
             throw `cannot call exit decorator function '${functionName}' is not defined in the blackboard`;
         }

--- a/src/decorators/exit.js
+++ b/src/decorators/exit.js
@@ -20,7 +20,7 @@ export default function Exit(functionName, ...args) {
             type: this.getType(),
             isGuard: this.isGuard(),
             functionName: this.getFunctionName(),
-            arguments: args
+            arguments: args || []
         };
     };
 
@@ -33,10 +33,10 @@ export default function Exit(functionName, ...args) {
     this.callBlackboardFunction = (board, isSuccess, isAborted) => {
         // Call the blackboard function if it exists.
         if (typeof board[functionName] === "function") {
-            board[functionName].apply(board, [
-                { succeeded: isSuccess, aborted: isAborted },
-                ...(args || [])
-            ]);
+            board[functionName].call(board, 
+                                     { succeeded: isSuccess, aborted: isAborted },
+                                     ...(args || [])
+                                    );
         } else {
             throw `cannot call exit decorator function '${functionName}' is not defined in the blackboard`;
         }

--- a/src/decorators/exit.js
+++ b/src/decorators/exit.js
@@ -4,7 +4,7 @@ import Decorator from './decorator'
  * An EXIT decorator which defines a blackboard function to call when the decorated node is updated and moves to a finished state or is aborted.
  * @param functionName The name of the blackboard function to call.
  */
-export default function Exit(functionName) {
+export default function Exit(functionName, ...args) {
     Decorator.call(this, "exit");
 
     /**
@@ -19,7 +19,8 @@ export default function Exit(functionName) {
         return {
             type: this.getType(),
             isGuard: this.isGuard(),
-            functionName: this.getFunctionName()
+            functionName: this.getFunctionName(),
+            arguments: args
         };
     };
 
@@ -32,7 +33,10 @@ export default function Exit(functionName) {
     this.callBlackboardFunction = (board, isSuccess, isAborted) => {
         // Call the blackboard function if it exists.
         if (typeof board[functionName] === "function") {
-            board[functionName].call(board, { succeeded: isSuccess, aborted: isAborted });
+            board[functionName].apply(board, [
+                { succeeded: isSuccess, aborted: isAborted },
+                ...(args || [])
+            ]);
         } else {
             throw `cannot call exit decorator function '${functionName}' is not defined in the blackboard`;
         }

--- a/src/decorators/guards/until.js
+++ b/src/decorators/guards/until.js
@@ -4,8 +4,8 @@ import Decorator from '../decorator'
  * An UNTIL guard which is satisfied as long as the given condition remains false.
  * @param condition The name of the condition function that determines whether the guard is satisfied.
  */
-export default function Until(condition, ...args) {
-    Decorator.call(this, "until");
+export default function Until(condition, args) {
+    Decorator.call(this, "until", args);
 
     /**
      * Gets whether the decorator is a guard.
@@ -25,7 +25,7 @@ export default function Until(condition, ...args) {
             type: this.getType(),
             isGuard: this.isGuard(),
             condition: this.getCondition(),
-            arguments: args
+            arguments: this.getArguments()
         };
     };
 
@@ -37,7 +37,7 @@ export default function Until(condition, ...args) {
     this.isSatisfied = (board) => {
         // Call the condition function to determine whether this guard is satisfied.
         if (typeof board[condition] === "function") {
-            return !!!(board[condition].apply(board, args || []));
+            return !!!(board[condition].apply(board, this.getArguments()));
         } else {
             throw `cannot evaluate node guard as function '${condition}' is not defined in the blackboard`;
         }

--- a/src/decorators/guards/until.js
+++ b/src/decorators/guards/until.js
@@ -4,7 +4,7 @@ import Decorator from '../decorator'
  * An UNTIL guard which is satisfied as long as the given condition remains false.
  * @param condition The name of the condition function that determines whether the guard is satisfied.
  */
-export default function Until(condition) {
+export default function Until(condition, ...args) {
     Decorator.call(this, "until");
 
     /**
@@ -24,7 +24,8 @@ export default function Until(condition) {
         return {
             type: this.getType(),
             isGuard: this.isGuard(),
-            condition: this.getCondition()
+            condition: this.getCondition(),
+            arguments: args
         };
     };
 
@@ -36,7 +37,7 @@ export default function Until(condition) {
     this.isSatisfied = (board) => {
         // Call the condition function to determine whether this guard is satisfied.
         if (typeof board[condition] === "function") {
-            return !!!(board[condition].call(board));
+            return !!!(board[condition].apply(board, args || []));
         } else {
             throw `cannot evaluate node guard as function '${condition}' is not defined in the blackboard`;
         }

--- a/src/decorators/guards/while.js
+++ b/src/decorators/guards/while.js
@@ -5,7 +5,7 @@ import Decorator from '../decorator'
  * @param condition The name of the condition function that determines whether the guard is satisfied.
  */
 export default function While(condition, ...args) {
-    Decorator.call(this, "while");
+    Decorator.call(this, "while", args);
 
     /**
      * Gets whether the decorator is a guard.
@@ -25,7 +25,7 @@ export default function While(condition, ...args) {
             type: this.getType(),
             isGuard: this.isGuard(),
             condition: this.getCondition(),
-            arguments: args
+            arguments: this.getArguments()
         };
     };
 
@@ -37,7 +37,7 @@ export default function While(condition, ...args) {
     this.isSatisfied = (board) => {
         // Call the condition function to determine whether this guard is satisfied.
         if (typeof board[condition] === "function") {
-            return !!(board[condition].apply(board, args || []));
+            return !!(board[condition].apply(board, this.getArguments()));
         } else {
             throw `cannot evaluate node guard as function '${condition}' is not defined in the blackboard`;
         }

--- a/src/decorators/guards/while.js
+++ b/src/decorators/guards/while.js
@@ -4,7 +4,7 @@ import Decorator from '../decorator'
  * A WHILE guard which is satisfied as long as the given condition remains true.
  * @param condition The name of the condition function that determines whether the guard is satisfied.
  */
-export default function While(condition) {
+export default function While(condition, ...args) {
     Decorator.call(this, "while");
 
     /**
@@ -24,7 +24,8 @@ export default function While(condition) {
         return {
             type: this.getType(),
             isGuard: this.isGuard(),
-            condition: this.getCondition()
+            condition: this.getCondition(),
+            arguments: args
         };
     };
 
@@ -36,7 +37,7 @@ export default function While(condition) {
     this.isSatisfied = (board) => {
         // Call the condition function to determine whether this guard is satisfied.
         if (typeof board[condition] === "function") {
-            return !!(board[condition].call(board));
+            return !!(board[condition].apply(board, args || []));
         } else {
             throw `cannot evaluate node guard as function '${condition}' is not defined in the blackboard`;
         }

--- a/src/decorators/step.js
+++ b/src/decorators/step.js
@@ -4,7 +4,7 @@ import Decorator from './decorator'
  * A STEP decorator which defines a blackboard function to call when the decorated node is updated.
  * @param functionName The name of the blackboard function to call.
  */
-export default function Step(functionName) {
+export default function Step(functionName, ...args) {
     Decorator.call(this, "step");
 
     /**
@@ -19,7 +19,8 @@ export default function Step(functionName) {
         return {
             type: this.getType(),
             isGuard: this.isGuard(),
-            functionName: this.getFunctionName()
+            functionName: this.getFunctionName(),
+            arguments: args
         };
     };
 
@@ -30,7 +31,7 @@ export default function Step(functionName) {
     this.callBlackboardFunction = (board) => {
         // Call the blackboard function if it exists.
         if (typeof board[functionName] === "function") {
-            board[functionName].call(board);
+            board[functionName].apply(board, args || []);
         } else {
             throw `cannot call entry decorator function '${functionName}' is not defined in the blackboard`;
         }

--- a/src/decorators/step.js
+++ b/src/decorators/step.js
@@ -4,8 +4,8 @@ import Decorator from './decorator'
  * A STEP decorator which defines a blackboard function to call when the decorated node is updated.
  * @param functionName The name of the blackboard function to call.
  */
-export default function Step(functionName, ...args) {
-    Decorator.call(this, "step");
+export default function Step(functionName, args) {
+    Decorator.call(this, "step", args);
 
     /**
      * Gets the function name.
@@ -20,7 +20,7 @@ export default function Step(functionName, ...args) {
             type: this.getType(),
             isGuard: this.isGuard(),
             functionName: this.getFunctionName(),
-            arguments: args
+            arguments: this.getArguments()
         };
     };
 
@@ -31,7 +31,7 @@ export default function Step(functionName, ...args) {
     this.callBlackboardFunction = (board) => {
         // Call the blackboard function if it exists.
         if (typeof board[functionName] === "function") {
-            board[functionName].apply(board, args || []);
+            board[functionName].apply(board, this.getArguments());
         } else {
             throw `cannot call entry decorator function '${functionName}' is not defined in the blackboard`;
         }

--- a/src/nodes/action.js
+++ b/src/nodes/action.js
@@ -7,7 +7,7 @@ import State from "../state";
  * @param decorators The node decorators.
  * @param actionName The action name.
  */
-export default function Action(decorators, actionName) {
+export default function Action(decorators, actionName, actionArguments) {
     Leaf.call(this, "action", decorators);
 
     /**
@@ -48,7 +48,7 @@ export default function Action(decorators, actionName) {
         // - The finished state of this action node.
         // - A promise to return a finished node state.
         // - Undefined if the node should remain in the running state.
-        const updateResult = action.call(board);
+        const updateResult = action.call(board, actionArguments || []);
 
         if (updateResult instanceof Promise) {
             updateResult.then(

--- a/src/nodes/action.js
+++ b/src/nodes/action.js
@@ -11,7 +11,7 @@ export default function Action(decorators, actionName, actionArguments) {
     Leaf.call(this, "action", decorators);
 
     /**
-     * Whether there is a pending update promise. 
+     * Whether there is a pending update promise.
      */
     let isUsingUpdatePromise = false;
 
@@ -19,7 +19,7 @@ export default function Action(decorators, actionName, actionArguments) {
      * The finished state result of an update promise.
      */
     let updatePromiseStateResult = null;
-   
+
     /**
      * Update the node.
      * @param board The board.
@@ -37,7 +37,7 @@ export default function Action(decorators, actionName, actionArguments) {
                 // Set the state of this node to match the state returned by the promise.
                 this.setState(updatePromiseStateResult);
             }
-            
+
             return;
         }
 
@@ -48,7 +48,7 @@ export default function Action(decorators, actionName, actionArguments) {
         // - The finished state of this action node.
         // - A promise to return a finished node state.
         // - Undefined if the node should remain in the running state.
-        const updateResult = action.call(board, actionArguments || []);
+        const updateResult = action.apply(board, actionArguments || []);
 
         if (updateResult instanceof Promise) {
             updateResult.then(
@@ -65,7 +65,7 @@ export default function Action(decorators, actionName, actionArguments) {
 
                     // Set pending update promise state result to be processed on next update.
                     updatePromiseStateResult = result;
-                }, 
+                },
                 (reason) => {
                     // If 'isUpdatePromisePending' is null then the promise was cleared as it was resolving, probably via an abort of reset.
                     if (!isUsingUpdatePromise) {

--- a/src/nodes/condition.js
+++ b/src/nodes/condition.js
@@ -7,7 +7,7 @@ import State from "../state";
  * @param decorators The node decorators.
  * @param condition The name of the condition function. 
  */
-export default function Condition(decorators, condition) {
+export default function Condition(decorators, condition, conditionArguments) {
     Leaf.call(this, "condition", decorators);
    
     /**
@@ -18,7 +18,7 @@ export default function Condition(decorators, condition) {
     this.onUpdate = function(board) {
         // Call the condition function to determine the state of this node, but it must exist in the blackboard.
         if (typeof board[condition] === "function") {
-            this.setState(!!(board[condition].call(board)) ? State.SUCCEEDED : State.FAILED);
+            this.setState(!!(board[condition].call(board, conditionArguments || [])) ? State.SUCCEEDED : State.FAILED);
         } else {
             throw `cannot update condition node as function '${condition}' is not defined in the blackboard`;
         }

--- a/src/nodes/condition.js
+++ b/src/nodes/condition.js
@@ -5,11 +5,11 @@ import State from "../state";
  * A Condition leaf node.
  * This will succeed or fail immediately based on a board predicate, without moving to the 'RUNNING' state.
  * @param decorators The node decorators.
- * @param condition The name of the condition function. 
+ * @param condition The name of the condition function.
  */
 export default function Condition(decorators, condition, conditionArguments) {
     Leaf.call(this, "condition", decorators);
-   
+
     /**
      * Update the node.
      * @param board The board.
@@ -18,7 +18,11 @@ export default function Condition(decorators, condition, conditionArguments) {
     this.onUpdate = function(board) {
         // Call the condition function to determine the state of this node, but it must exist in the blackboard.
         if (typeof board[condition] === "function") {
-            this.setState(!!(board[condition].call(board, conditionArguments || [])) ? State.SUCCEEDED : State.FAILED);
+            this.setState(
+                !!(board[condition].apply(board, conditionArguments || []))
+                    ? State.SUCCEEDED
+                    : State.FAILED
+            );
         } else {
             throw `cannot update condition node as function '${condition}' is not defined in the blackboard`;
         }

--- a/src/rootASTNodesBuilder.js
+++ b/src/rootASTNodesBuilder.js
@@ -209,7 +209,7 @@ const ASTNodeFactories = {
             return new Condition(
                 this.decorators,
                 this.conditionFunction,
-		this.conditionArguments
+                this.conditionArguments
             );
         }
     }),
@@ -426,9 +426,9 @@ export default function buildRootASTNodes(tokens) {
                 }
 
                 // The condition name will be defined as a node argument.
-                const tokenArguments = getArguments(tokens);
-                node.conditionFunction = tokenArguments.pop();
-                node.conditionArguments = tokenArguments || [];
+                const conditionArguments = getArguments(tokens);
+                node.conditionFunction = conditionArguments.pop();
+                node.conditionArguments = conditionArguments;
 
                 // Try to pick any decorators off of the token stack.
                 node.decorators = getDecorators(tokens);
@@ -525,9 +525,9 @@ export default function buildRootASTNodes(tokens) {
                 }
 
                 // The action name will be defined as a node argument.
-                const tokenArguments = getArguments(tokens);
-                node.actionName = tokenArguments.pop();
-                node.actionArguments = tokenArguments || [];
+                const actionArguments = getArguments(tokens);
+                node.actionName = actionArguments.pop();
+                node.actionArguments = actionArguments;
 
                 // Try to pick any decorators off of the token stack.
                 node.decorators = getDecorators(tokens);

--- a/src/rootASTNodesBuilder.js
+++ b/src/rootASTNodesBuilder.js
@@ -18,11 +18,11 @@ import Step from './decorators/step'
  * The node decorator factories.
  */
 const DecoratorFactories = {
-    "WHILE": (condition) => new While(condition),
-    "UNTIL": (condition) => new Until(condition),
-    "ENTRY": (functionName) => new Entry(functionName),
-    "EXIT": (functionName) => new Exit(functionName),
-    "STEP": (functionName) => new Step(functionName)
+    "WHILE": (condition, ...args) => new While(condition, ...args),
+    "UNTIL": (condition, ...args) => new Until(condition, ...args),
+    "ENTRY": (functionName, ...args) => new Entry(functionName, ...args),
+    "EXIT": (functionName, ...args) => new Exit(functionName, ...args),
+    "STEP": (functionName, ...args) => new Step(functionName, ...args)
 };
 
 /**

--- a/src/rootASTNodesBuilder.js
+++ b/src/rootASTNodesBuilder.js
@@ -18,18 +18,18 @@ import Step from './decorators/step'
  * The node decorator factories.
  */
 const DecoratorFactories = {
-    "WHILE": (condition, ...args) => new While(condition, ...args),
-    "UNTIL": (condition, ...args) => new Until(condition, ...args),
-    "ENTRY": (functionName, ...args) => new Entry(functionName, ...args),
-    "EXIT": (functionName, ...args) => new Exit(functionName, ...args),
-    "STEP": (functionName, ...args) => new Step(functionName, ...args)
+    "WHILE": (condition, args) => new While(condition, args),
+    "UNTIL": (condition, args) => new Until(condition, args),
+    "ENTRY": (functionName, args) => new Entry(functionName, args),
+    "EXIT": (functionName, args) => new Exit(functionName, args),
+    "STEP": (functionName, args) => new Step(functionName, args)
 };
 
 /**
  * The AST node factories.
  */
 const ASTNodeFactories = {
-    "ROOT": () => ({ 
+    "ROOT": () => ({
         type: "root",
         decorators: [],
         name: null,
@@ -45,14 +45,14 @@ const ASTNodeFactories = {
                 throw "a root node must have a single child";
             }
         },
-        createNodeInstance: function (namedRootNodeProvider, visitedBranches) { 
+        createNodeInstance: function (namedRootNodeProvider, visitedBranches) {
             return new Root(
                 this.decorators,
                 this.children[0].createNodeInstance(namedRootNodeProvider, visitedBranches.slice())
             );
         }
     }),
-    "BRANCH": () => ({ 
+    "BRANCH": () => ({
         type: "branch",
         branchName: "",
         validate: function (depth) {},
@@ -83,7 +83,7 @@ const ASTNodeFactories = {
                 throw "a selector node must have at least a single child";
             }
         },
-        createNodeInstance: function (namedRootNodeProvider, visitedBranches) { 
+        createNodeInstance: function (namedRootNodeProvider, visitedBranches) {
             return new Selector(
                 this.decorators,
                 this.children.map((child) => child.createNodeInstance(namedRootNodeProvider, visitedBranches.slice()))
@@ -93,14 +93,14 @@ const ASTNodeFactories = {
     "SEQUENCE": () => ({
         type: "sequence",
         decorators: [],
-        children: [], 
+        children: [],
         validate: function (depth) {
             // A sequence node must have at least a single node.
             if (this.children.length < 1) {
                 throw "a sequence node must have at least a single child";
             }
         },
-        createNodeInstance: function (namedRootNodeProvider, visitedBranches) { 
+        createNodeInstance: function (namedRootNodeProvider, visitedBranches) {
             return new Sequence(
                 this.decorators,
                 this.children.map((child) => child.createNodeInstance(namedRootNodeProvider, visitedBranches.slice()))
@@ -110,14 +110,14 @@ const ASTNodeFactories = {
     "PARALLEL": () => ({
         type: "parallel",
         decorators: [],
-        children: [], 
+        children: [],
         validate: function (depth) {
             // A parallel node must have at least a single node.
             if (this.children.length < 1) {
                 throw "a parallel node must have at least a single child";
             }
         },
-        createNodeInstance: function (namedRootNodeProvider, visitedBranches) { 
+        createNodeInstance: function (namedRootNodeProvider, visitedBranches) {
             return new Parallel(
                 this.decorators,
                 this.children.map((child) => child.createNodeInstance(namedRootNodeProvider, visitedBranches.slice()))
@@ -128,14 +128,14 @@ const ASTNodeFactories = {
         type: "lotto",
         decorators: [],
         children: [],
-        tickets: [], 
+        tickets: [],
         validate: function (depth) {
             // A lotto node must have at least a single node.
             if (this.children.length < 1) {
                 throw "a lotto node must have at least a single child";
             }
         },
-        createNodeInstance: function (namedRootNodeProvider, visitedBranches) { 
+        createNodeInstance: function (namedRootNodeProvider, visitedBranches) {
             return new Lotto(
                 this.decorators,
                 this.tickets,
@@ -155,14 +155,14 @@ const ASTNodeFactories = {
                 throw "a repeat node must have a single child";
             }
 
-            // A repeat node must have a positive number of iterations if defined. 
+            // A repeat node must have a positive number of iterations if defined.
             if (this.iterations !== null && this.iterations < 0) {
                 throw "a repeat node must have a positive number of iterations if defined";
             }
 
             // There is validation to carry out if a longest duration was defined.
             if (this.maximumIterations !== null) {
-                // A repeat node must have a positive maximum iterations count if defined. 
+                // A repeat node must have a positive maximum iterations count if defined.
                 if (this.maximumIterations < 0) {
                     throw "a repeat node must have a positive maximum iterations count if defined";
                 }
@@ -173,7 +173,7 @@ const ASTNodeFactories = {
                 }
             }
         },
-        createNodeInstance: function (namedRootNodeProvider, visitedBranches) { 
+        createNodeInstance: function (namedRootNodeProvider, visitedBranches) {
             return new Repeat(
                 this.decorators,
                 this.iterations,
@@ -192,7 +192,7 @@ const ASTNodeFactories = {
                 throw "a flip node must have a single child";
             }
         },
-        createNodeInstance: function (namedRootNodeProvider, visitedBranches) { 
+        createNodeInstance: function (namedRootNodeProvider, visitedBranches) {
             return new Flip(
                 this.decorators,
                 this.children[0].createNodeInstance(namedRootNodeProvider, visitedBranches.slice())
@@ -205,7 +205,7 @@ const ASTNodeFactories = {
         conditionFunction: "",
         conditionArguments: [],
         validate: function (depth) {},
-        createNodeInstance: function (namedRootNodeProvider, visitedBranches) { 
+        createNodeInstance: function (namedRootNodeProvider, visitedBranches) {
             return new Condition(
                 this.decorators,
                 this.conditionFunction,
@@ -219,14 +219,14 @@ const ASTNodeFactories = {
         duration: null,
         longestDuration: null,
         validate: function (depth) {
-            // A wait node must have a positive duration. 
+            // A wait node must have a positive duration.
             if (this.duration < 0) {
                 throw "a wait node must have a positive duration";
             }
 
             // There is validation to carry out if a longest duration was defined.
             if (this.longestDuration) {
-                // A wait node must have a positive longest duration. 
+                // A wait node must have a positive longest duration.
                 if (this.longestDuration < 0) {
                     throw "a wait node must have a positive longest duration if one is defined";
                 }
@@ -237,7 +237,7 @@ const ASTNodeFactories = {
                 }
             }
         },
-        createNodeInstance: function (namedRootNodeProvider, visitedBranches) { 
+        createNodeInstance: function (namedRootNodeProvider, visitedBranches) {
             return new Wait(
                 this.decorators,
                 this.duration,
@@ -255,7 +255,7 @@ const ASTNodeFactories = {
             return new Action(
                 this.decorators,
                 this.actionName,
-		this.actionsArguments,
+                this.actionsArguments,
             );
         }
     })
@@ -319,7 +319,7 @@ export default function buildRootASTNodes(tokens) {
                 stack.push(node.children);
                 break;
 
-            case "BRANCH": 
+            case "BRANCH":
                 // Create a BRANCH AST node.
                 node = ASTNodeFactories.BRANCH();
 
@@ -329,7 +329,7 @@ export default function buildRootASTNodes(tokens) {
                 // We must have arguments defined, as we require a branch name argument.
                 if (tokens[0] !== "[") {
                     throw "expected single branch name argument";
-                } 
+                }
 
                 // The branch name will be defined as a node argument.
                 const branchArguments = getArguments(tokens);
@@ -340,10 +340,10 @@ export default function buildRootASTNodes(tokens) {
                     node.branchName = branchArguments[0];
                 } else {
                     throw "expected single branch name argument";
-                } 
+                }
                 break;
 
-            case "SELECTOR": 
+            case "SELECTOR":
                 // Create a SELECTOR AST node.
                 node = ASTNodeFactories.SELECTOR();
 
@@ -413,7 +413,7 @@ export default function buildRootASTNodes(tokens) {
                 stack.push(node.children);
                 break;
 
-            case "CONDITION": 
+            case "CONDITION":
                 // Create a CONDITION AST node.
                 node = ASTNodeFactories.CONDITION();
 
@@ -423,12 +423,12 @@ export default function buildRootASTNodes(tokens) {
                 // We must have arguments defined, as we require a condition function name argument.
                 if (tokens[0] !== "[") {
                     throw "expected single condition name argument";
-                } 
+                }
 
                 // The condition name will be defined as a node argument.
-                const [conditionFunction, ...conditionArguments] = getArguments(tokens);
-                node.conditionFunction = conditionFunction;
-                node.conditionArguments = conditionArguments || [];
+                const tokenArguments = getArguments(tokens);
+                node.conditionFunction = tokenArguments.pop();
+                node.conditionArguments = tokenArguments || [];
 
                 // Try to pick any decorators off of the token stack.
                 node.decorators = getDecorators(tokens);
@@ -522,18 +522,18 @@ export default function buildRootASTNodes(tokens) {
                 // We must have arguments defined, as we require an action name argument.
                 if (tokens[0] !== "[") {
                     throw "expected single action name argument";
-                } 
+                }
 
                 // The action name will be defined as a node argument.
-                const [actionName, ...actionArguments] = getArguments(tokens);
-                node.actionName = actionName;
-                node.actionArguments = actionArguments || [];
+                const tokenArguments = getArguments(tokens);
+                node.actionName = tokenArguments.pop();
+                node.actionArguments = tokenArguments || [];
 
                 // Try to pick any decorators off of the token stack.
                 node.decorators = getDecorators(tokens);
                 break;
 
-            case "}": 
+            case "}":
                 // The '}' character closes the current scope.
                 stack.pop();
                 break;
@@ -553,7 +553,7 @@ export default function buildRootASTNodes(tokens) {
     };
 
     // Start node validation from the definition root.
-    validateASTNode({ 
+    validateASTNode({
         children: stack[0],
         validate: function (depth) {
             // We must have at least one node defined as the definition scope, which should be a root node.
@@ -601,12 +601,12 @@ function popAndCheck(tokens, expected) {
 
     // We were expecting another token.
     if (popped === undefined) {
-        throw "unexpected end of definition"; 
+        throw "unexpected end of definition";
     }
 
     // If an expected token was defined, was it the expected one?
     if (expected && popped.toUpperCase() !== expected.toUpperCase()) {
-        throw "unexpected token found on the stack. Expected '" + expected + "' but got '" + popped + "'"; 
+        throw "unexpected token found on the stack. Expected '" + expected + "' but got '" + popped + "'";
     }
 
     // Return the popped token.
@@ -668,12 +668,12 @@ function getArguments(tokens, argumentValidator, validationFailedMessage) {
  * @returns An array od decorators defined by any directly following tokens.
  */
 function getDecorators(tokens) {
-	// Create an array to hold any decorators found. 
+	// Create an array to hold any decorators found.
 	const decorators = [];
-  
+
     // Keep track of names of decorators that we have found on the token stack, as we cannot have duplicates.
     const decoratorsFound = [];
-  
+
     // Try to get the decorator factory for the next token.
     let decoratorFactory = DecoratorFactories[(tokens[0] || "").toUpperCase()];
 
@@ -689,20 +689,22 @@ function getDecorators(tokens) {
         // The decorator definition should consist of the tokens 'NAME', '(', 'ARGUMENT' and ')'.
         popAndCheck(tokens, tokens[0].toUpperCase());
         popAndCheck(tokens, "(");
-	// store decorator name, condition, and condition arguments
-        const decoratorArgument = [];
-        let arg = popAndCheck(tokens);
+
+        // store decorator name, condition, and condition arguments
+        const decoratorArguments = [];
+        const decoratorName = popAndCheck(tokens);
+        let arg = popAndCheck(tokens)
         while (arg !== ")") {
-            decoratorArgument.push(arg);
+            decoratorArguments.push(arg);
             arg = popAndCheck(tokens)
         }
 
         // Create the decorator and add it to the array of decorators found.
-        decorators.push(decoratorFactory(decoratorArgument));
+        decorators.push(decoratorFactory(decoratorName, decoratorArguments));
 
         // Try to get the next decorator name token, as there could be multiple.
         decoratorFactory = DecoratorFactories[(tokens[0] || "").toUpperCase()];
     }
-  
+
 	return decorators;
 };

--- a/src/state.js
+++ b/src/state.js
@@ -1,11 +1,21 @@
 /**
  * Enumeration of node states.
  */
+const StateNameEnum = {
+    READY: "mistreevous.ready",
+    RUNNING: "mistreevous.running",
+    SUCCEEDED: "mistreevous.succeeded",
+    FAILED: "mistreevous.failed"
+}
+
 const State = {
-    READY: Symbol("mistreevous.ready"),
-    RUNNING: Symbol("mistreevous.running"),
-    SUCCEEDED: Symbol("mistreevous.succeeded"),
-    FAILED: Symbol("mistreevous.failed")
+    READY: Symbol(StateNameEnum.READY),
+    RUNNING: Symbol(StateNameEnum.RUNNING),
+    SUCCEEDED: Symbol(StateNameEnum.SUCCEEDED),
+    FAILED: Symbol(StateNameEnum.FAILED)
 };
 
-export { State as default };
+export {
+    StateNameEnum,
+    State as default
+};

--- a/test/BehaviourTree.js
+++ b/test/BehaviourTree.js
@@ -5,14 +5,60 @@ var assert = chai.assert;
 
 describe("A BehaviourTree instance", () => {
   describe("has initialisation logic that", () => {
+
     describe("should error when", () => {
       it("the tree definition argument is not a string", () => {
-        assert.throws(() => new mistreevous.BehaviourTree(null, {}), Error, "the tree definition must be a string");
+        const scenario = () => new mistreevous.BehaviourTree(null, {})
+        assert.throws(scenario, Error, mistreevous.BehaviourTree.ERROR_DEFINITION_IS_NOT_A_STRING);
       });
 
       it("the blackboard object is not defined", () => {
         assert.throws(() => new mistreevous.BehaviourTree("", undefined), Error, "the blackboard must be defined");
       });
     });
+
+    describe("should not error when", () => {
+      it("the tree definition contains conditions with arguments", () => {
+        const definition = `
+          root {
+            selector {
+                repeat until(keyIsDown spacebar) {
+                    sequence {
+                        wait [1000, 2500]
+                    }
+                }
+            }
+          }
+        `;
+
+        const blackboard = {
+          keyIsDown: (key) => !!key
+        }
+
+        const scenario = () => new mistreevous.BehaviourTree(definition, blackboard);
+        assert.doesNotThrow(scenario, Error);
+
+      })
+
+      it("the tree definition contains actions with arguments", () => {
+        const definition = `
+          root {
+            lotto {
+                action [mutter angrily]
+                action [mutter loudly]
+                action [mutter nonsense]
+            }
+          }
+        `;
+
+        const blackboard = {
+          mutter: (content) => `[mutters] ${content}`
+        }
+
+        const scenario = () => new mistreevous.BehaviourTree(definition, blackboard);
+        assert.doesNotThrow(scenario, Error);
+
+      })
+    })
   });
 });


### PR DESCRIPTION
There's not tests for this. But it seems to me that this should work.

- [x] Store Decorator Condition Arguments: Store more than just the Condition name.
- [x] Action Arguments: de-structure name and arguments. store arguments for later.
- [x] When called, Send Action Arguments as well
- [x] Upgrade all Guards to accept condition arguments and pass them along when calling condition
- [ ] Add some tests, make them pass