### PR TITLE
Bundle for web platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,11 +17,12 @@
     "should": "^1.3.0"
   },
   "scripts": {
-    "build": "npm-run-all build:esbuild build:typecheck",
-    "watch": "npm run build:esbuild -- --watch",
+    "build": "npm-run-all build:node build:web build:typecheck",
+    "watch": "npm run build:node -- --watch",
     "test": "npm-run-all build:format build test:unit-test",
     "build:format": "prettier --write \"src/**/*.ts\"",
-    "build:esbuild": "esbuild ./src/index.js --bundle --sourcemap --outdir=dist --platform=node",
+    "build:node": "esbuild ./src/index.js --bundle --sourcemap --outdir=dist --platform=node",
+    "build:web": "esbuild ./src/index.js --bundle --sourcemap --outdir=dist --platform=browser --global-name=mistreevous --outfile=bundle.js",
     "build:typecheck": "tsc --emitDeclarationOnly",
     "test:unit-test": "mocha \"test/**/*.js\""
   },
@@ -41,7 +42,7 @@
     "machine",
     "state"
   ],
-  "author": "nikolas howard smells",
+  "author": "nikolas howard smells bad",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/nikkorn/mistreevous/issues"


### PR DESCRIPTION
I haven't tested whether this is working, but I think you'll need something along these lines.

esbuild docs on the CLI parameters: https://esbuild.github.io/api/

- `--platform=browser` should give you a file that can be referenced from a `<script>` tag and will automatically run.
- `--global-name=mistreevous` should set the name of the global variable, that the exports from `src/index.ts` will be available under.
- I've passed `--outfile=bundle.js`, so the node and browser exports can both live in harmony in the compiled JS folder.
- There might be some property you can set on `package.json` to reference both output files, so both would be included in the npm publish?

I think previously you were creating a UMD module, which esbuild doesn't support IIRC. Its worth still publishing the node version, because I think that's what people will want to consume from webpack etc.